### PR TITLE
adding jacoco to verificate test coverage and updating readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,24 @@ World Cup Scoreboard library that shows all the ongoing matches and their scores
 - Creating and storing matches in the scoreboard before they start and after they are finished can be beneficial for managing the lifecycle of matches and maintaining historical data. However, this might not be Scoreboards responsibility. In the provided solution, the Scoreboard does not store Match instances before a match starts and after it is completed.
 
 
+### Guidelines
+
+#### Running the Project
+
+To build the project, ensure you have Java and Gradle installed on your system. You can start by compiling the code and running the project using the following command:
+
+```bash
+./gradlew build
+```
+
+#### Generating a test coverage report
+
+To generate test coverage report run command:
+
+```bash
+./gradlew test jacocoTestReport
+```
+
+Test report will be located at: **/build/reports/jacoco/test/html/index.html**
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'jacoco'
 }
 
 group = 'scoreboard'
@@ -9,7 +10,34 @@ repositories {
     mavenCentral()
 }
 
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+build {
+    dependsOn test, jacocoTestReport, jacocoTestCoverageVerification
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = 1.0
+            }
+        }
+    }
+}
+
 dependencies {
+    implementation 'com.github.bibsysdev:core:2.2.4'
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.github.bibsysdev:nvatestutils:2.2.4'

--- a/src/main/java/scoreboard/model/Match.java
+++ b/src/main/java/scoreboard/model/Match.java
@@ -7,6 +7,7 @@ import static scoreboard.model.Score.initialScore;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
+import nva.commons.core.JacocoGenerated;
 import scoreboard.exceptions.InvalidMatchException;
 import scoreboard.exceptions.InvalidScoreException;
 import scoreboard.exceptions.InvalidTeamException;
@@ -40,11 +41,13 @@ public class Match {
         return new Match(homeTeam, awayTeam);
     }
 
+    @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hash(getHomeTeam(), getAwayTeam(), getIdentifier(), getStartTime(), getScore());
     }
 
+    @JacocoGenerated
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Match match)) {

--- a/src/main/java/scoreboard/model/Score.java
+++ b/src/main/java/scoreboard/model/Score.java
@@ -1,6 +1,7 @@
 package scoreboard.model;
 
 import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 import scoreboard.exceptions.InvalidScoreException;
 
 public class Score {
@@ -26,11 +27,13 @@ public class Score {
         return new Score(homeTeam, awayTeam);
     }
 
+    @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hash(home, away);
     }
 
+    @JacocoGenerated
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Score score)) {

--- a/src/main/java/scoreboard/model/Team.java
+++ b/src/main/java/scoreboard/model/Team.java
@@ -2,6 +2,7 @@ package scoreboard.model;
 
 import static java.util.Objects.isNull;
 import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 import scoreboard.exceptions.InvalidTeamException;
 
 public class Team {
@@ -20,11 +21,13 @@ public class Team {
         return new Team(name);
     }
 
+    @JacocoGenerated
     @Override
     public int hashCode() {
         return Objects.hashCode(getName());
     }
 
+    @JacocoGenerated
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Team team)) {


### PR DESCRIPTION
- Adding jacoco as part of gradle build job to run test coverage verification.
- Adding nva core library to annotate equals and hashcode methods with `@JacocoGenerated` in order to exclude them from test coverage report. 
- Updating README file with updated build and test report generating instructions.